### PR TITLE
Update ngx_http_quic_module.c

### DIFF
--- a/src/ngx_http_quic_module.c
+++ b/src/ngx_http_quic_module.c
@@ -148,7 +148,7 @@ ngx_http_use_quic(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     if (qscf == NULL) {
       ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-                     "quic stack \"%V\" not exist", value[1]);
+                     "quic stack \"%V\" not exist", &value[1]);
       return NGX_CONF_ERROR;
     }
 


### PR DESCRIPTION
enable_quic 指令配置不存在的 quic_stack 会导致 core down；把ngx_str_t 值当指针用了